### PR TITLE
addExposureDaysToEnd

### DIFF
--- a/PatientLevelPrediction.Rmd
+++ b/PatientLevelPrediction.Rmd
@@ -619,7 +619,7 @@ We can use the `loadPlpData()` function to load the data in a future session.
 
 ### Additional Inclusion Criteria
 
-The final study population is obtained by applying additional constraints on the two earlier defined cohorts, e.g., a minimum time at risk can be enforced (`requireTimeAtRisk, minTimeAtRisk`) and we can specify if this also applies to patients with the outcome (`includeAllOutcomes`). Here we also specify the start and end of the risk window relative to target cohort start. For example, if we like the risk window to start 30 days after the at-risk cohort start and end a year later we can set `riskWindowStart = 30` and `riskWindowEnd = 365`. In some cases the risk window needs to start at the cohort end date. This can be achieved by setting `addExposureToStart = TRUE` which adds the cohort (exposure) time to the start date.
+The final study population is obtained by applying additional constraints on the two earlier defined cohorts, e.g., a minimum time at risk can be enforced (`requireTimeAtRisk, minTimeAtRisk`) and we can specify if this also applies to patients with the outcome (`includeAllOutcomes`). Here we also specify the start and end of the risk window relative to target cohort start. For example, if we like the risk window to start 30 days after the at-risk cohort start and end a year later we can set `riskWindowStart = 30` and `riskWindowEnd = 365`. In some cases the risk window needs to start at the cohort end date. This can be achieved by setting `addExposureToEnd = TRUE` which adds the cohort (exposure) time to the end date.
 
 In the example below all the settings we defined for our study are imposed:
 


### PR DESCRIPTION
modified function name in the text for consistency between the sentences.


In some cases the risk window needs to start at the cohort end date. This can be achieved by setting `addExposureToStart = TRUE` which adds the cohort (exposure) time to the start date.

--->
In some cases the risk window needs to start at the cohort end date. This can be achieved by setting `addExposureToEnd = TRUE` which adds the cohort (exposure) time to the end date.
