### PR TITLE
Fix typo in table 4.6 32034 -> 32035

### DIFF
--- a/CommonDataModel.Rmd
+++ b/CommonDataModel.Rmd
@@ -231,7 +231,7 @@ Column name|Value|Explanation
 |VISIT_START_ DATETIME|2013-01-17 00:00:00|The date and time of the Visit. The time is unknown, so midnight is used.|
 |VISIT_END_DATE|2013-01-24|The end date of the Visit. If this is a one-day Visit the end date should match the start date.|
 |VISIT_END_DATETIME|2013-01-24 00:00:00|The date and time of the Visit end. The time is unknown, so midnight is used.|
-|VISIT_TYPE_ CONCEPT_ID|32034|This provides information about the provenance of the Visit record, i.e. does it come from an insurance claim, hospital billing, EHR record, etc. For this example the concept ID [32035](http://athena.ohdsi.org/search-terms/terms/32035) ("Visit derived from EHR encounter record") is used as the encounters are similar to Electronic Health Records|
+|VISIT_TYPE_ CONCEPT_ID|32035|This provides information about the provenance of the Visit record, i.e. does it come from an insurance claim, hospital billing, EHR record, etc. For this example the concept ID [32035](http://athena.ohdsi.org/search-terms/terms/32035) ("Visit derived from EHR encounter record") is used as the encounters are similar to Electronic Health Records|
 |PROVIDER_ID*|NULL|If the encounter record has a provider associated the ID for that provider goes into this field. This should be the content of the PROVIDER_ID field from the PROVIDER table.|
 |CARE_SITE_ID|NULL|If the encounter record has a Care Site associated, the ID for that Care Site goes into this field. This should be the CARE_SITE_ID from the CARE_SITE table.|
 |VISIT_SOURCE_ VALUE|inpatient|The Visit value as it appears in the source goes here. Lauren's data do not have that.|


### PR DESCRIPTION
The explanation text does not match the value in the table. 
![image](https://user-images.githubusercontent.com/7249907/108631227-7223b000-7471-11eb-9580-235591ffe7fa.png)
32034 could have worked also but it seems that's a billing record, not an encounter reord.