### PR TITLE
Oracle Table Name length

### DIFF
--- a/SqlAndR.Rmd
+++ b/SqlAndR.Rmd
@@ -238,7 +238,7 @@ translate(sql, targetDialect = "oracle", oracleTempSchema = "temp_schema")
 
 Note that the user will need to have write privileges on `temp_schema`.
 
-Also note that because Oracle has a limit on table names of 30 characters. **Temp table names are only allowed to be at most 22 characters long**, because else the name will become too long after appending the session ID.
+Also note that because Oracle (prior to version 12.2, released in 2016) has a limit on table names of 30 characters. **Temp table names are only allowed to be at most 22 characters long**, because else the name will become too long after appending the session ID.
 
 Furthermore, remember that temp tables are not automatically dropped on Oracle, so you will need to explicitly ```TRUNCATE``` and ```DROP``` all temp tables once you're done with them to prevent orphan tables accumulating in the Oracle temp schema.
 


### PR DESCRIPTION
Oracle table names can be longer than 30 bytes as of version 12.2, which was released in 2016.  I wonder if this should be considered in future table naming?