### PR TITLE
three backtics

### DIFF
--- a/PatientLevelPrediction.Rmd
+++ b/PatientLevelPrediction.Rmd
@@ -925,7 +925,7 @@ We have added functionality to automatically generate a word document we can use
              includePredictionPicture = TRUE,
              includeAttritionPlot = TRUE,
              outputLocation = "<your location>")
-````
+```
 
 For more details see the help page of the function.
 


### PR DESCRIPTION
fixes error
```
The closing backticks on line 928 ("````") in PatientLevelPrediction.Rmd do not match the opening backticks "```" on line 914. You are recommended to fix either the opening or closing delimiter of the code chunk to use exactly the same numbers of backticks and same level of indentation (or blockquote).
```